### PR TITLE
Mix respawns and ghosts

### DIFF
--- a/PermuteMMO.Lib/Util/Calculations.cs
+++ b/PermuteMMO.Lib/Util/Calculations.cs
@@ -1,0 +1,91 @@
+﻿using PKHeX.Core;
+
+namespace PermuteMMO.Lib;
+
+/// <summary>
+/// Runs simple forwards calculations for seeds.
+/// </summary>
+public static class Calculations
+{
+    /// <summary>
+    /// Gets the group seed value after the provided advance steps.
+    /// </summary>
+    public static ulong GetGroupSeed(in ulong groupSeed, IEnumerable<Advance> advances)
+    {
+        ulong seed = GetGroupSeed(groupSeed, 4);
+        foreach (var advance in advances)
+        {
+            var count = advance.AdvanceCount();
+            var rng = new Xoroshiro128Plus(seed);
+            for (int i = 0; i < count; i++)
+            {
+                _ = rng.Next();
+                _ = rng.Next(); // Unknown
+            }
+            seed = rng.Next(); // Reset the seed for future spawns.
+        }
+
+        return seed;
+    }
+
+    /// <summary>
+    /// Gets the group seed value after spawning the specified count of entities.
+    /// </summary>
+    public static ulong GetGroupSeed(ulong seed, int count)
+    {
+        var rng = new Xoroshiro128Plus(seed);
+        for (int i = 0; i < count; i++)
+        {
+            _ = rng.Next();
+            _ = rng.Next(); // Unknown
+        }
+
+        return rng.Next(); // Reset the seed for future spawns.
+    }
+
+    /// <summary>
+    /// Gets the slot generation seed (slot, entity seed) that re-spawns at a 1-based index.
+    /// </summary>
+    /// <param name="groupSeed">Group seed to spawn things for this regeneration round.</param>
+    /// <param name="spawnIndex">1-indexed (not 0) spawn index.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public static ulong GetGenerateSeed(in ulong groupSeed, in int spawnIndex)
+    {
+        var rng = new Xoroshiro128Plus(groupSeed);
+        for (int i = 1; i <= spawnIndex; i++)
+        {
+            var subSeed = rng.Next();
+            _ = rng.Next(); // Unknown
+
+            if (i == spawnIndex)
+                return subSeed;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(spawnIndex));
+    }
+
+    /// <summary>
+    /// Gets the entity template seed (slot, entity seed) that re-spawns at a 1-based index.
+    /// </summary>
+    /// <param name="groupSeed">Group seed to spawn things for this regeneration round.</param>
+    /// <param name="spawnIndex">1-indexed (not 0) spawn index.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public static ulong GetEntitySeed(in ulong groupSeed, in int spawnIndex)
+    {
+        var rng = new Xoroshiro128Plus(groupSeed);
+        for (int i = 1; i <= spawnIndex; i++)
+        {
+            var subSeed = rng.Next();
+            _ = rng.Next(); // Unknown
+
+            if (i != spawnIndex)
+                continue;
+
+            var poke = new Xoroshiro128Plus(subSeed);
+            _ = poke.Next(); // slot
+            return poke.Next();
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(spawnIndex));
+    }
+}

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using FluentAssertions;
 using Newtonsoft.Json;
 using PermuteMMO.Lib;
 using PKHeX.Core;
 using Xunit;
+using static PermuteMMO.Lib.Advance;
 
 namespace PermuteMMO.Tests;
 
@@ -30,5 +32,36 @@ public static class UtilTests
 
         string argument = "/select, \"" + fileName + "\"";
         Process.Start("explorer.exe", argument);
+    }
+
+    [Fact]
+    public static void Garchomp()
+    {
+        var json = new UserEnteredSpawnInfo
+        {
+            Seed = "12880307074085126207",
+            Species = 444,
+            BaseCount = 9,
+            BaseTable = "0x85714105CF348588",
+            BonusCount = 7,
+            BonusTable = "0x8AE0881E5F939184",
+        };
+        var spawn = json.GetSpawn();
+
+        ulong seed = json.GetSeed();
+        var sequence = new[] { A2, A1, A3 };
+        const int index = 2;
+
+        var gs = Calculations.GetGroupSeed(seed, sequence);
+        var respawnSeed = Calculations.GetGenerateSeed(gs, index);
+        var entitySeed = Calculations.GetEntitySeed(gs, index);
+        var result = SpawnGenerator.Generate(respawnSeed, spawn.BonusTable, SpawnType.MMO);
+        result.IsShiny.Should().BeTrue();
+        result.IsAlpha.Should().BeTrue();
+        entitySeed.Should().Be(0xc50932b428a734fd);
+
+        var permute = Permuter.Permute(spawn, seed);
+        var match = permute.Results.Find(z => z.Entity.Seed == respawnSeed);
+        match.Should().NotBeNull();
     }
 }


### PR DESCRIPTION
Triggering the last visible respawn with a partial fill (2 left to spawn, KO 3) will spawn 2 real & 1 ghost. 

Previous logic maximized the amount of ghost spawns, and was operating under the assumption that ghosts do not spawn if anything is actually respawned. Not true.

Adds a test case to double check certain results.