### PR TITLE
Extract state tracking model, refactor for multi-wave

### DIFF
--- a/PermuteMMO.ConsoleApp/Program.cs
+++ b/PermuteMMO.ConsoleApp/Program.cs
@@ -9,7 +9,6 @@ if (File.Exists(json))
 {
     var info = JsonDecoder.Deserialize<UserEnteredSpawnInfo>(File.ReadAllText(json));
     var spawner = info.GetSpawn();
-    SpawnGenerator.MaxShinyRolls = spawner.Type is SpawnType.MMO ? 19 : 32;
     ConsolePermuter.PermuteSingle(spawner, info.GetSeed(), info.Species);
 
     Console.WriteLine("Press [ENTER] to exit.");

--- a/PermuteMMO.Lib/ConsolePermuter.cs
+++ b/PermuteMMO.Lib/ConsolePermuter.cs
@@ -36,14 +36,7 @@ public static class ConsolePermuter
 
                 Debug.Assert(spawner.HasBase);
                 var seed = spawner.SpawnSeed;
-                var spawn = new SpawnInfo
-                {
-                    BaseCount = spawner.BaseCount,
-                    BaseTable = spawner.BaseTable,
-
-                    BonusCount = spawner.HasBonus ? spawner.BonusCount : 0,
-                    BonusTable = spawner.HasBonus ? spawner.BonusTable : 0,
-                };
+                var spawn = new SpawnInfo(spawner);
 
                 var result = Permuter.Permute(spawn, seed);
                 if (!result.HasResults)
@@ -59,8 +52,8 @@ public static class ConsolePermuter
                 Console.WriteLine($"Spawner {j+1} at ({spawner.X:F1}, {spawner.Y:F1}, {spawner.Z}) shows {SpeciesName.GetSpeciesName(spawner.DisplaySpecies, 2)}");
                 Console.WriteLine($"Parameters: {spawn}");
                 Console.WriteLine($"Seed: {seed}");
-                bool skittishBase = SpawnGenerator.IsSkittish(spawn.BaseTable);
-                bool skittishBonus = SpawnGenerator.IsSkittish(spawn.BonusTable);
+                bool skittishBase = SpawnGenerator.IsSkittish(spawn.Set.Table);
+                bool skittishBonus = spawn.GetNextWave(out var next) && SpawnGenerator.IsSkittish(next.Set.Table);
                 var lines = result.GetLines(skittishBase, skittishBonus);
                 foreach (var line in lines)
                     Console.WriteLine(line);
@@ -98,13 +91,7 @@ public static class ConsolePermuter
             Debug.Assert(spawner.IsValid);
 
             var seed = spawner.SpawnSeed;
-            var spawn = new SpawnInfo
-            {
-                BaseCount = spawner.BaseCount,
-                BaseTable = spawner.DisplaySpecies,
-                Type = SpawnType.Outbreak,
-            };
-
+            var spawn = new SpawnInfo(spawner);
             var result = Permuter.Permute(spawn, seed);
             if (!result.HasResults)
             {
@@ -144,8 +131,8 @@ public static class ConsolePermuter
         }
         else
         {
-            bool skittishBase = SpawnGenerator.IsSkittish(spawn.BaseTable);
-            bool skittishBonus = SpawnGenerator.IsSkittish(spawn.BonusTable);
+            bool skittishBase = SpawnGenerator.IsSkittish(spawn.Set.Table);
+            bool skittishBonus = spawn.GetNextWave(out var next) && SpawnGenerator.IsSkittish(next.Set.Table);
             var lines = result.GetLines(skittishBase, skittishBonus);
             foreach (var line in lines)
                 Console.WriteLine(line);

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -16,7 +16,7 @@ public static class SpawnGenerator
     public static PokedexSave8a Pokedex => SaveFile.PokedexSave;
     public static byte[] BackingArray => SaveFile.Blocks.GetBlock(0x02168706).Data;
     public static bool HasCharm { get; set; } = true;
-    public static int MaxShinyRolls { get; set; }
+    public static bool UseSaveFileShinyRolls { get; set; }
     #endregion
 
     private static SAV8LA GetFake()
@@ -25,6 +25,7 @@ public static class SpawnGenerator
         {
             var data = File.ReadAllBytes("main");
             var sav = new SAV8LA(data);
+            UseSaveFileShinyRolls = true;
             HasCharm = sav.Inventory.Any(z => z.Items.Any(i => i.Index == 632 && i.Count is not 0));
             return sav;
         }
@@ -110,8 +111,8 @@ public static class SpawnGenerator
 
     private static int GetRerollCount(in int species, SpawnType type)
     {
-        if (MaxShinyRolls is not 0)
-            return MaxShinyRolls;
+        if (!UseSaveFileShinyRolls)
+            return (int)type;
         bool perfect = Pokedex.IsPerfect(species);
         bool complete = Pokedex.IsComplete(species);
         return 1 + (complete ? 1 : 0) + (perfect ? 2 : 0) + (HasCharm ? 3 : 0) + (int)type;

--- a/PermuteMMO.Lib/Generation/SpawnType.cs
+++ b/PermuteMMO.Lib/Generation/SpawnType.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public enum SpawnType
 {
-    Regular = 0,
-    MMO = 12,
-    Outbreak = 25,
+    Regular  = 7 + 0,
+    MMO      = 7 + 12,
+    Outbreak = 7 + 25,
 }

--- a/PermuteMMO.Lib/Permutation/Advance.cs
+++ b/PermuteMMO.Lib/Permutation/Advance.cs
@@ -17,7 +17,7 @@ public enum Advance : byte
     G1,
     G2,
     G3,
- // G4 is equivalent to CW
+ // G4 is equivalent to CR
 
  // S1 is equivalent to A1
     S2,

--- a/PermuteMMO.Lib/Permutation/PermuteMeta.cs
+++ b/PermuteMMO.Lib/Permutation/PermuteMeta.cs
@@ -13,6 +13,9 @@ public sealed record PermuteMeta(SpawnInfo Spawner)
     public readonly List<PermuteResult> Results = new();
     private readonly List<Advance> Advances = new();
 
+    public bool HasResults => Results.Count is not 0;
+    public int MaxAlive { get; } = Spawner.MaxAlive;
+
     /// <summary>
     /// Signals the start of a recursive permutation step.
     /// </summary>
@@ -103,6 +106,4 @@ public sealed record PermuteMeta(SpawnInfo Spawner)
         }
         return true;
     }
-
-    public bool HasResults => Results.Count is not 0;
 }

--- a/PermuteMMO.Lib/Permutation/PermuteMeta.cs
+++ b/PermuteMMO.Lib/Permutation/PermuteMeta.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Stores object-type references for cleaner passing internally. Only refer to <see cref="Results"/> when done.
 /// </summary>
-public sealed record PermuteMeta(SpawnInfo Spawner)
+public sealed record PermuteMeta(SpawnInfo Spawner, int MaxDepth)
 {
     /// <summary>
     /// Global configuration for determining if a <see cref="EntityResult"/> is a suitable result.
@@ -14,7 +14,14 @@ public sealed record PermuteMeta(SpawnInfo Spawner)
     private readonly List<Advance> Advances = new();
 
     public bool HasResults => Results.Count is not 0;
-    public int MaxAlive { get; } = Spawner.MaxAlive;
+    public SpawnInfo Spawner { get; set; } = Spawner;
+
+    public (bool CanContinue, SpawnInfo Next) AttemptNextWave()
+    {
+        if (Advances.Count < MaxDepth && Spawner.GetNextWave(out var next))
+            return (true, next);
+        return (false, Spawner);
+    }
 
     /// <summary>
     /// Signals the start of a recursive permutation step.
@@ -30,10 +37,10 @@ public sealed record PermuteMeta(SpawnInfo Spawner)
     /// <summary>
     /// Stores a result.
     /// </summary>
-    public void AddResult(EntityResult entity, in int index, in bool isBonus)
+    public void AddResult(EntityResult entity, in int index)
     {
         var steps = Advances.ToArray();
-        var result = new PermuteResult(steps, entity, index, isBonus);
+        var result = new PermuteResult(steps, entity, index);
         Results.Add(result);
     }
 

--- a/PermuteMMO.Lib/Permutation/PermuteResult.cs
+++ b/PermuteMMO.Lib/Permutation/PermuteResult.cs
@@ -3,20 +3,33 @@
 /// <summary>
 /// <see cref="EntityResult"/> wrapper with some utility logic to print to console.
 /// </summary>
-public sealed record PermuteResult(Advance[] Advances, EntityResult Entity, in int SpawnIndex, in bool IsBonus)
+public sealed record PermuteResult(Advance[] Advances, EntityResult Entity, in int SpawnIndex)
 {
+    private bool IsBonus => Array.IndexOf(Advances, Advance.CR) != -1;
+    private int WaveIndex => Advances.Count(adv => adv == Advance.CR);
+
     public string GetLine(PermuteResult? prev, bool isActionMultiResult, bool skittishBase, bool skittishBonus)
     {
         var steps = GetSteps(prev);
         var feasibility = GetFeasibility(Advances, skittishBase, skittishBonus);
         // 37 total characters for the steps:
-        // 10+7 spawner has 6+(3)+3=12 max permutations, +"SB|", remove last |; (3*12+2)=37.
-        var line = $"* {steps,-37} >>> {(IsBonus ? "Bonus " : "      ")}Spawn{SpawnIndex} = {Entity.GetSummary()}{feasibility}";
+        // 10+7 spawner has 6+(3)+3=12 max permutations, +"CR|", remove last |; (3*12+2)=37.
+        var line = $"* {steps,-37} >>> {GetWaveIndicator()}Spawn{SpawnIndex} = {Entity.GetSummary()}{feasibility}";
         if (prev != null)
             line += " ~~ Chain result!";
         if (isActionMultiResult)
             line += " ~~ Spawns multiple results!";
         return line;
+    }
+
+    private string GetWaveIndicator()
+    {
+        if (!IsBonus)
+            return "      ";
+        var waveIndex = WaveIndex;
+        if (waveIndex == 1)
+            return "Bonus ";
+        return    $"Wave {waveIndex}";
     }
 
     public string GetSteps(PermuteResult? prev = null)

--- a/PermuteMMO.Lib/SpawnState.cs
+++ b/PermuteMMO.Lib/SpawnState.cs
@@ -1,0 +1,97 @@
+﻿using System.Diagnostics;
+
+namespace PermuteMMO.Lib;
+
+/// <summary>
+/// Models the state of an Entity Spawner, indicating how it can be mutated by player actions.
+/// </summary>
+/// <param name="Count">Total count of entities that can be spawned by the spawner.</param>
+/// <param name="MaxAlive">Maximum count of entities that can be alive at a given time.</param>
+/// <param name="Alive">Current count of entities alive.</param>
+/// <param name="Ghost">Current count of fake entities.</param>
+/// <param name="AliveAggressive">Current count of aggressive entities alive.</param>
+public readonly record struct SpawnState(in int Count, in int MaxAlive, in int Alive = 0, in int Ghost = 0, in int AliveAggressive = 0)
+{
+    /// <summary> Current count of unpopulated entities. </summary>
+    public int Dead { get; init; } = MaxAlive;
+
+    /// <summary> Total count of entities that can exist as ghosts. </summary>
+    /// <remarks> Completely filling with ghost slots will start the next wave rather than add ghosts. </remarks>
+    private int MaxGhosts => MaxAlive - 1;
+    /// <summary> Current count of timid entities alive. </summary>
+    public int AliveTimid => Alive - AliveAggressive;
+
+    /// <summary> Maximum count of entities that can be battled in the current state. </summary>
+    public int MaxCountBattle => Math.Min(Alive, AliveAggressive + 1);
+
+    /// <summary> Maximum count of entities that can be scared in the current state. </summary>
+    public int MaxCountScare => Math.Min(Alive, AliveTimid);
+
+    /// <summary> Indicates if ghost entities can be added to the spawner. </summary>
+    /// <remarks> Only call this if <see cref="Count"/> is zero. </remarks>
+    public bool CanAddGhosts => Ghost != MaxGhosts;
+
+    /// <summary> Indicates if ghost entities can be added to the spawner. </summary>
+    /// <remarks> Only call this if <see cref="Count"/> is zero. </remarks>
+    public int EmptyGhostSlots => MaxGhosts - Ghost;
+
+    /// <summary>
+    /// Returns a spawner state after knocking out existing entities.
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="count"/> is 1, this is the same as capturing a single Entity out of battle.
+    /// </remarks>
+    public SpawnState Knockout(in int count)
+    {
+        // Prefer to knock out the Skittish, and any required Aggressives
+        var newAggro = AliveAggressive - count + 1;
+        Debug.Assert(newAggro >= 0);
+        return this with { Alive = Alive - count, Dead = Dead + count, AliveAggressive = newAggro };
+    }
+
+    /// <summary>
+    /// Returns a spawner state after scaring existing entities away.
+    /// </summary>
+    public SpawnState Scare(in int count)
+    {
+        // Can only scare Skittish
+        Debug.Assert(AliveTimid >= count);
+        return this with { Alive = Alive - count, Dead = Dead + count };
+    }
+
+    /// <summary>
+    /// Returns a spawner state after generating new entities.
+    /// </summary>
+    public SpawnState Generate(in int count, in int aggro) => this with
+    {
+        Count = Count - count,
+        Alive = Alive + count,
+        Dead = Dead - count,
+        Ghost = Dead - count,
+        AliveAggressive = AliveAggressive + aggro,
+    };
+
+    /// <summary>
+    /// Returns a spawner state with additional ghosts added.
+    /// </summary>
+    public SpawnState AddGhosts(in int count) => this with
+    {
+        Alive = Alive - count,
+        Dead = Dead + count,
+        Ghost = Ghost + count,
+    };
+
+    /// <summary>
+    /// Gets the counts of what to generate when regenerating a spawner.
+    /// </summary>
+    /// <remarks> Only call this if <see cref="Count"/> is NOT zero. </remarks>
+    public (int Empty, int Respawn, int Ghosts) GetRespawnInfo()
+    {
+        var emptySlots = Dead;
+        var respawn = Math.Min(Count, emptySlots);
+        var ghosts = emptySlots == respawn ? 0 : MaxAlive - respawn;
+
+        Debug.Assert(respawn != 0);
+        return (emptySlots, respawn, ghosts);
+    }
+}

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -10,6 +10,7 @@ public sealed record SpawnInfo
     public ulong BaseTable { get; init; }
     public ulong BonusTable { get; init; }
     public SpawnType Type { get; init; } = SpawnType.MMO;
+    public int MaxAlive { get; init; } = 4;
 
     public bool HasBase => BaseTable is not (0 or 0xCBF29CE484222645);
     public bool HasBonus => BonusTable is not (0 or 0xCBF29CE484222645);

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -1,17 +1,50 @@
-﻿namespace PermuteMMO.Lib;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace PermuteMMO.Lib;
 
 /// <summary>
 /// Top-level spawner details to feed into the permutation logic.
 /// </summary>
-public sealed record SpawnInfo
+public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next = null)
 {
-    public int BaseCount { get; init; }
-    public int BonusCount { get; init; }
-    public ulong BaseTable { get; init; }
-    public ulong BonusTable { get; init; }
-    public SpawnType Type { get; init; } = SpawnType.MMO;
-    public int MaxAlive { get; init; } = 4;
+    private static readonly SpawnDetail MMO = new(SpawnType.MMO, 4);
+    private static readonly SpawnDetail Outbreak = new(SpawnType.Outbreak, 4);
 
-    public bool HasBase => BaseTable is not (0 or 0xCBF29CE484222645);
-    public bool HasBonus => BonusTable is not (0 or 0xCBF29CE484222645);
+    private SpawnInfo? Next { get; set; } = Next;
+
+    public bool GetNextWave([NotNullWhen(true)] out SpawnInfo? next) => (next = Next) != null;
+
+    public SpawnInfo(MassiveOutbreakSpawner8a spawner) : this(MMO, new SpawnSet(spawner.BaseTable, spawner.BaseCount), GetBonusChain(spawner)) { }
+    public SpawnInfo(MassOutbreakSpawner8a spawner) : this(Outbreak, new SpawnSet(spawner.DisplaySpecies, spawner.BaseCount)) { }
+
+    public static SpawnInfo GetMMO(ulong baseTable, in int baseCount, ulong bonusTable, in int bonusCount)
+    {
+        var child = new SpawnInfo(MMO, new SpawnSet(bonusTable, bonusCount));
+        return new SpawnInfo(MMO, new SpawnSet(baseTable, baseCount), child);
+    }
+
+    private static SpawnInfo? GetBonusChain(MassiveOutbreakSpawner8a spawner)
+    {
+        if (!spawner.HasBonus)
+            return null;
+        return new SpawnInfo(MMO, new SpawnSet(spawner.BonusTable, spawner.BonusCount));
+    }
+
+    public static SpawnInfo GetMO(ulong table, int count) => new(Outbreak, new SpawnSet(table, count));
+
+    public static SpawnInfo GetLoop(SpawnDetail detail, SpawnSet set)
+    {
+        var result = new SpawnInfo(detail, set);
+        result.Next = result;
+        return result;
+    }
+}
+
+public readonly record struct SpawnSet(ulong Table, int Count);
+
+public readonly record struct SpawnDetail(SpawnType SpawnType, int MaxAlive);
+
+public static class HashUtil
+{
+    public static bool IsNonZeroHash(in ulong hash) => hash is not (0 or 0xCBF29CE484222645);
 }

--- a/PermuteMMO.Lib/Util/UserEnteredSpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/UserEnteredSpawnInfo.cs
@@ -19,18 +19,14 @@ public sealed record UserEnteredSpawnInfo
     {
         var table = Parse(BaseTable);
         var bonus = Parse(BonusTable);
-        var type = bonus is 0 && table is 0 ? SpawnType.Outbreak : SpawnType.MMO;
-        if (table < 1000)
-            table = Species;
-
-        return new SpawnInfo
+        bool isOutbreak = !HashUtil.IsNonZeroHash(table) && !HashUtil.IsNonZeroHash(bonus);
+        if (isOutbreak)
         {
-            BaseCount = BaseCount,
-            BonusCount = BonusCount,
-            BaseTable = table,
-            BonusTable = bonus,
-            Type = type,
-        };
+            if (table < 1000)
+                table = Species;
+            return SpawnInfo.GetMO(table, BaseCount);
+        }
+        return SpawnInfo.GetMMO(table, BaseCount, bonus, BonusCount);
     }
 
     private static ulong Parse(string hex)

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -13,15 +13,7 @@ public sealed class SimpleTests
     [InlineData(0xA5D779D8831721FD, 10, 6, (ushort)25)]
     public void First(in ulong seed, in int baseCount, in int bonusCount, in ushort species)
     {
-        var spawner = new SpawnInfo
-        {
-            BaseCount = baseCount,
-            BaseTable = 0x7FA3A1DE69BD271E,
-
-            BonusCount = bonusCount,
-            BonusTable = 0x44182B854CD3745D,
-        };
-
+        var spawner = SpawnInfo.GetMMO(0x7FA3A1DE69BD271E, baseCount, 0x44182B854CD3745D, bonusCount);
         var result = Permuter.Permute(spawner, seed);
         result.Results.Find(z => z.Entity.PID == 0x6f4edff0).Should().NotBeNull();
 

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -39,25 +39,17 @@ public static class UtilTests
     [Fact]
     public static void Garchomp()
     {
-        var json = new UserEnteredSpawnInfo
-        {
-            Seed = "12880307074085126207",
-            Species = 444,
-            BaseCount = 9,
-            BaseTable = "0x85714105CF348588",
-            BonusCount = 7,
-            BonusTable = "0x8AE0881E5F939184",
-        };
-        var spawn = json.GetSpawn();
-
-        ulong seed = json.GetSeed();
+        var spawn = SpawnInfo.GetMMO(0x85714105CF348588, 9, 0x8AE0881E5F939184, 7);
+        const ulong seed = 12880307074085126207u;
         var sequence = new[] { A2, A1, A3 };
         const int index = 2;
 
         var gs = Calculations.GetGroupSeed(seed, sequence);
         var respawnSeed = Calculations.GetGenerateSeed(gs, index);
         var entitySeed = Calculations.GetEntitySeed(gs, index);
-        var result = SpawnGenerator.Generate(respawnSeed, spawn.BonusTable, SpawnType.MMO);
+        if (!spawn.GetNextWave(out var next))
+            throw new Exception();
+        var result = SpawnGenerator.Generate(respawnSeed, next.Set.Table, next.Detail.SpawnType);
         result.IsShiny.Should().BeTrue();
         result.IsAlpha.Should().BeTrue();
         entitySeed.Should().Be(0xc50932b428a734fd);
@@ -70,24 +62,15 @@ public static class UtilTests
     [Fact]
     public static void Stantler()
     {
-        var json = new UserEnteredSpawnInfo
-        {
-            Seed = "88514016295302425",
-            Species = 234,
-            BaseCount = 10,
-            BaseTable = "0x5BFA9CCA4ED8142B",
-            BonusCount = 6,
-            BonusTable = "0xC213942F6D31614C",
-        };
-        var spawn = json.GetSpawn();
+        var spawn = SpawnInfo.GetMMO(0x5BFA9CCA4ED8142B, 10, 0xC213942F6D31614C, 6);
+        const ulong seed = 88514016295302425u;
 
         // Spawn 4 pokemon
-        var seed = json.GetSeed();
         var entities = new List<EntityResult>();
         for (int i = 1; i <= 4; i++)
         {
             var genSeed = Calculations.GetGenerateSeed(seed, i);
-            var entity = SpawnGenerator.Generate(genSeed, spawn.BaseTable, SpawnType.MMO);
+            var entity = SpawnGenerator.Generate(genSeed, spawn.Set.Table, spawn.Detail.SpawnType);
             entities.Add(entity);
         }
 


### PR DESCRIPTION
Extracts some logic for respawning into the spawner model. Can be experimentally reused for different spawner counts.

Since I got carried away...

Refactors SpawnInfo to be a linked list allowing circular wave referencing. Still need to investigate quirks of regular spawners. Might need to tweak the recursion depth or refactor to not be recursion if a stack overflow is nigh :)

Don't have json for wild encounters, but this could technically support permuting wild stuff (respawn via resting) or future encounter types with multi waves (pls give us challenging wave encounters for SV or Nightfall DLC). 

Removes isBonus passing for each recursion step, ez perf gain w/ 1 less primitive being passed.