### PR TITLE
Initial handling of regular spawner permutation

### DIFF
--- a/PermuteMMO.Lib/ConsolePermuter.cs
+++ b/PermuteMMO.Lib/ConsolePermuter.cs
@@ -35,7 +35,7 @@ public static class ConsolePermuter
                     continue;
 
                 Debug.Assert(spawner.HasBase);
-                var seed = spawner.SpawnSeed;
+                var seed = spawner.GroupSeed;
                 var spawn = new SpawnInfo(spawner);
 
                 var result = Permuter.Permute(spawn, seed);
@@ -88,7 +88,7 @@ public static class ConsolePermuter
             }
             Debug.Assert(spawner.IsValid);
 
-            var seed = spawner.SpawnSeed;
+            var seed = spawner.GroupSeed;
             var spawn = new SpawnInfo(spawner);
             var result = Permuter.Permute(spawn, seed);
             if (!result.HasResults)

--- a/PermuteMMO.Lib/Generation/EntityResult.cs
+++ b/PermuteMMO.Lib/Generation/EntityResult.cs
@@ -10,7 +10,10 @@ public sealed class EntityResult
     public string Name { get; init; } = string.Empty;
     public readonly byte[] IVs = { byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue };
 
-    public ulong Seed { get; init; }
+    public ulong GroupSeed { get; init; }
+    public int Index { get; init; }
+    public ulong SlotSeed { get; init; }
+    public ulong GenSeed { get; init; }
     public int Level { get; init; }
 
     public uint EC { get; set; }

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -9,7 +9,7 @@ namespace PermuteMMO.Lib;
 /// </summary>
 public static class SpawnGenerator
 {
-    public static readonly IReadOnlyDictionary<ulong, SlotDetail[]> EncounterTables = JsonDecoder.GetDictionary(Resources.mmo_es);
+    public static readonly IDictionary<ulong, SlotDetail[]> EncounterTables = JsonDecoder.GetDictionary(Resources.mmo_es);
 
     /// <summary>
     /// Generates an <see cref="EntityResult"/> from the input <see cref="seed"/> and <see cref="table"/>.

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -14,7 +14,7 @@ public static class SpawnGenerator
     /// <summary>
     /// Generates an <see cref="EntityResult"/> from the input <see cref="seed"/> and <see cref="table"/>.
     /// </summary>
-    public static EntityResult Generate(in ulong groupseed, in int index, in ulong seed, in ulong table, SpawnType type, bool noAlpha)
+    public static EntityResult? Generate(in ulong groupseed, in int index, in ulong seed, in ulong table, SpawnType type, bool noAlpha)
     {
         var slotrng = new Xoroshiro128Plus(seed);
 
@@ -22,6 +22,9 @@ public static class SpawnGenerator
         if (noAlpha)
             slots = slots.Where(z => !z.IsAlpha).ToList();
         var slotSum = slots.Sum(z => z.Rate);
+        if (slotSum == 0)
+            return null;
+
         var slotroll = slotrng.NextFloat(slotSum);
         var slot = GetSlot(slots, slotroll);
         var genseed = slotrng.Next();

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -14,7 +14,7 @@ public static class SpawnGenerator
     /// <summary>
     /// Generates an <see cref="EntityResult"/> from the input <see cref="seed"/> and <see cref="table"/>.
     /// </summary>
-    public static EntityResult Generate(in ulong seed, in ulong table, SpawnType type)
+    public static EntityResult Generate(in ulong groupseed, in int index, in ulong seed, in ulong table, SpawnType type)
     {
         var slotrng = new Xoroshiro128Plus(seed);
 
@@ -38,7 +38,10 @@ public static class SpawnGenerator
             Level = level,
             IsAlpha = slot.IsAlpha,
 
-            Seed = seed,
+            GroupSeed = groupseed,
+            Index = index,
+            SlotSeed = seed,
+            GenSeed = genseed,
             Name = slot.Name,
         };
 

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -14,11 +14,13 @@ public static class SpawnGenerator
     /// <summary>
     /// Generates an <see cref="EntityResult"/> from the input <see cref="seed"/> and <see cref="table"/>.
     /// </summary>
-    public static EntityResult Generate(in ulong groupseed, in int index, in ulong seed, in ulong table, SpawnType type)
+    public static EntityResult Generate(in ulong groupseed, in int index, in ulong seed, in ulong table, SpawnType type, bool noAlpha)
     {
         var slotrng = new Xoroshiro128Plus(seed);
 
-        var slots = GetSlots(table);
+        IEnumerable<SlotDetail> slots = GetSlots(table);
+        if (noAlpha)
+            slots = slots.Where(z => !z.IsAlpha).ToList();
         var slotSum = slots.Sum(z => z.Rate);
         var slotroll = slotrng.NextFloat(slotSum);
         var slot = GetSlot(slots, slotroll);

--- a/PermuteMMO.Lib/Permutation/Advance.cs
+++ b/PermuteMMO.Lib/Permutation/Advance.cs
@@ -62,7 +62,19 @@ public static class AdvanceRemoval
         foreach (var adv in advances)
         {
             meta.Start(adv);
-            if (adv == CR)
+            if (meta.Spawner.RetainExisting)
+            {
+                var count = adv.AdvanceCount();
+                state = state.KnockoutAny(count);
+
+                var newAlive = meta.Spawner.Detail.MaxAlive; // meh
+
+                var maxAlive = Math.Max(newAlive, state.MaxAlive);
+                var newCount = Math.Max(0, maxAlive - state.Alive);
+                state = state with { MaxAlive = maxAlive, Count = newCount };
+                steps.Add(new(adv, state, seed));
+            }
+            else if (adv == CR)
             {
                 if (!meta.Spawner.GetNextWave(out var next))
                     throw new ArgumentException(nameof(adv));

--- a/PermuteMMO.Lib/Permutation/PermuteMeta.cs
+++ b/PermuteMMO.Lib/Permutation/PermuteMeta.cs
@@ -8,10 +8,14 @@ public sealed record PermuteMeta(SpawnInfo Spawner, int MaxDepth)
     /// <summary>
     /// Global configuration for determining if a <see cref="EntityResult"/> is a suitable result.
     /// </summary>
-    public static Func<EntityResult, IReadOnlyList<Advance>, bool> SatisfyCriteria { private get; set; } = (result, _) => result.IsShiny && result.IsAlpha;
+    public static Func<EntityResult, IReadOnlyList<Advance>, bool> SatisfyCriteria { get; set; } = (result, _) => result.IsShiny && result.IsAlpha;
+
+    public Func<EntityResult, IReadOnlyList<Advance>, bool> Criteria { get; set; } = SatisfyCriteria;
 
     public readonly List<PermuteResult> Results = new();
     private readonly List<Advance> Advances = new();
+
+    public PermuteMeta Copy() => new(Spawner, MaxDepth);
 
     public bool HasResults => Results.Count is not 0;
     public SpawnInfo Spawner { get; set; } = Spawner;
@@ -37,17 +41,17 @@ public sealed record PermuteMeta(SpawnInfo Spawner, int MaxDepth)
     /// <summary>
     /// Stores a result.
     /// </summary>
-    public void AddResult(EntityResult entity, in int index)
+    public void AddResult(EntityResult entity)
     {
         var steps = Advances.ToArray();
-        var result = new PermuteResult(steps, entity, index);
+        var result = new PermuteResult(steps, entity);
         Results.Add(result);
     }
 
     /// <summary>
     /// Checks if the <see cref="entity"/> is a suitable result.
     /// </summary>
-    public bool IsResult(EntityResult entity) => SatisfyCriteria(entity, Advances);
+    public bool IsResult(EntityResult entity) => Criteria(entity, Advances);
 
     /// <summary>
     /// Calls <see cref="PermuteResult.GetLine"/> for all objects in the result list.

--- a/PermuteMMO.Lib/Permutation/PermuteResult.cs
+++ b/PermuteMMO.Lib/Permutation/PermuteResult.cs
@@ -1,9 +1,12 @@
-﻿namespace PermuteMMO.Lib;
+﻿using System.Diagnostics;
+
+namespace PermuteMMO.Lib;
 
 /// <summary>
 /// <see cref="EntityResult"/> wrapper with some utility logic to print to console.
 /// </summary>
-public sealed record PermuteResult(Advance[] Advances, EntityResult Entity, in int SpawnIndex)
+[DebuggerDisplay($"{{{nameof(StepSummary)},nq}}")]
+public sealed record PermuteResult(Advance[] Advances, EntityResult Entity)
 {
     private bool IsBonus => Array.IndexOf(Advances, Advance.CR) != -1;
     private int WaveIndex => Advances.Count(adv => adv == Advance.CR);
@@ -14,7 +17,7 @@ public sealed record PermuteResult(Advance[] Advances, EntityResult Entity, in i
         var feasibility = GetFeasibility(Advances);
         // 37 total characters for the steps:
         // 10+7 spawner has 6+(3)+3=12 max permutations, +"CR|", remove last |; (3*12+2)=37.
-        var line = $"* {steps,-37} >>> {GetWaveIndicator()}Spawn{SpawnIndex} = {Entity.GetSummary()}{feasibility}";
+        var line = $"* {steps,-37} >>> {GetWaveIndicator()}Spawn{Entity.Index} = {Entity.GetSummary()}{feasibility}";
         if (prev != null || hasChildChain)
             line += " ~~ Chain result!";
         if (isActionMultiResult)
@@ -31,6 +34,8 @@ public sealed record PermuteResult(Advance[] Advances, EntityResult Entity, in i
             return "Bonus ";
         return    $"Wave {waveIndex}";
     }
+
+    private string StepSummary => $"{Entity.Index} {Entity.GroupSeed:X16} " + GetSteps();
 
     public string GetSteps(PermuteResult? prev = null)
     {

--- a/PermuteMMO.Lib/Permuter.cs
+++ b/PermuteMMO.Lib/Permuter.cs
@@ -154,6 +154,9 @@ public static class Permuter
 
             bool noAlpha = onlyOneAlpha && currentAlpha + alpha != 0;
             var generate = SpawnGenerator.Generate(seed, i, subSeed, table, meta.Spawner.Detail.SpawnType, noAlpha);
+            if (generate is null) // only a consideration for spawners with 100% static alphas, qty >1, maybe some weather/time tables?
+                continue; // empty ghost slot -- spawn failure.
+
             if (meta.IsResult(generate))
                 meta.AddResult(generate);
 

--- a/PermuteMMO.Lib/Permuter.cs
+++ b/PermuteMMO.Lib/Permuter.cs
@@ -137,7 +137,7 @@ public static class Permuter
     }
 
     private static (ulong Seed, int Alpha, int Aggressive, int Skittish, int Oblivious)
-        GenerateSpawns(PermuteMeta meta, in ulong table, in ulong seed, int count, in int ghosts, int currentAlpha, bool removeNewAlphas)
+        GenerateSpawns(PermuteMeta meta, in ulong table, in ulong seed, int count, in int ghosts, int currentAlpha, bool onlyOneAlpha)
     {
         int alpha = 0;
         int aggressive = 0;
@@ -152,10 +152,8 @@ public static class Permuter
             if (i <= ghosts)
                 continue; // end of wave ghost -- ghosts spawn first!
 
-            var generate = SpawnGenerator.Generate(seed, i, subSeed, table, meta.Spawner.Detail.SpawnType);
-            if (removeNewAlphas && generate.IsAlpha && currentAlpha + alpha != 0)
-                continue; // spawner disallows more Alphas
-
+            bool noAlpha = onlyOneAlpha && currentAlpha + alpha != 0;
+            var generate = SpawnGenerator.Generate(seed, i, subSeed, table, meta.Spawner.Detail.SpawnType, noAlpha);
             if (meta.IsResult(generate))
                 meta.AddResult(generate);
 

--- a/PermuteMMO.Lib/Permuter.cs
+++ b/PermuteMMO.Lib/Permuter.cs
@@ -146,8 +146,8 @@ public static class Permuter
         var rng = new Xoroshiro128Plus(seed);
         for (int i = 1; i <= count; i++)
         {
-            var subSeed = rng.Next();
-            _ = rng.Next(); // Unknown
+            var subSeed = rng.Next(); // generate/slot seed
+            _ = rng.Next(); // alpha move, don't care
 
             if (i <= ghosts)
                 continue; // end of wave ghost -- ghosts spawn first!

--- a/PermuteMMO.Lib/SpawnState.cs
+++ b/PermuteMMO.Lib/SpawnState.cs
@@ -11,7 +11,8 @@ namespace PermuteMMO.Lib;
 /// <param name="AliveAggressive">Current count of aggressive entities alive.</param>
 /// <param name="AliveBeta">Current count of timid entities alive.</param>
 /// <param name="AliveOblivious">Current count of oblivious entities alive.</param>
-public readonly record struct SpawnState(in int Count, in int MaxAlive, in int Ghost = 0, in int AliveAggressive = 0, in int AliveBeta = 0, in int AliveOblivious = 0)
+[DebuggerDisplay($"{{{nameof(State)},nq}}")]
+public readonly record struct SpawnState(in int Count, in int MaxAlive, in int Ghost = 0, in int AliveAlpha = 0, in int AliveAggressive = 0, in int AliveBeta = 0, in int AliveOblivious = 0)
 {
     /// <summary> Current count of unpopulated entities. </summary>
     public int Dead { get; init; } = MaxAlive;
@@ -34,13 +35,7 @@ public readonly record struct SpawnState(in int Count, in int MaxAlive, in int G
     /// <remarks>
     /// If <see cref="count"/> is 1, this is the same as capturing a single Aggressive Entity out of battle.
     /// </remarks>
-    public SpawnState KnockoutAggressive(in int count)
-    {
-        // Knock out required Aggressive
-        var newAggro = AliveAggressive - count;
-        Debug.Assert(newAggro >= 0);
-        return this with { Dead = Dead + count, AliveAggressive = newAggro };
-    }
+    public SpawnState KnockoutAggressive(in int count) => Remove(aggro: count);
 
     /// <summary>
     /// Returns a spawner state after knocking out existing entities.
@@ -48,64 +43,85 @@ public readonly record struct SpawnState(in int Count, in int MaxAlive, in int G
     /// <remarks>
     /// If <see cref="count"/> is 1, this is the same as capturing a single Beta Entity out of battle.
     /// </remarks>
-    public SpawnState KnockoutBeta(in int count)
-    {
-        // Prefer to knock out the Skittish, and any required Aggressive
-        var newAggro = AliveAggressive - count + 1;
-        Debug.Assert(newAggro >= 0);
-        return this with { Dead = Dead + count, AliveAggressive = newAggro, AliveBeta = AliveBeta - 1 };
-    }
+    public SpawnState KnockoutBeta(in int count) => Remove(aggro: count - 1, beta: 1);
 
     /// <summary>
     /// Returns a spawner state after knocking out existing entities.
     /// </summary>
-    public SpawnState KnockoutOblivious(int count)
-    {
-        // Knock out required Aggressive
-        var newOblivious = AliveOblivious - 1;
-        var newAggro = AliveAggressive - count + 1;
-        Debug.Assert(newOblivious >= 0);
-        Debug.Assert(newAggro >= 0);
-        return this with { Dead = Dead + 1, AliveOblivious = newOblivious };
-    }
+    public SpawnState KnockoutOblivious(int count) => Remove(aggro: count - 1, oblivious: 1);
 
     /// <summary>
     /// Returns a spawner state after scaring existing Beta entities away.
     /// </summary>
-    public SpawnState Scare(in int count)
-    {
-        // Can only scare Skittish
-        Debug.Assert(AliveBeta >= count);
-        return this with { AliveBeta = AliveBeta - count, Dead = Dead + count };
-    }
+    public SpawnState Scare(in int count) => Remove(beta: count);
 
     /// <summary>
     /// Returns a spawner state after generating new entities.
     /// </summary>
-    public SpawnState Generate(in int count, in int aggro, in int beta, in int oblivious) => this with
+    public SpawnState Add(in int count, in int alpha, in int aggro, in int beta, in int oblivious)
     {
-        Count = Count - count,
-        Dead = Dead - count,
-        Ghost = Dead - count,
-        AliveAggressive = AliveAggressive + aggro,
-        AliveBeta = AliveBeta + beta,
-        AliveOblivious = AliveOblivious + oblivious,
-    };
+        var nAlpha = AliveAlpha + alpha;
+        var nAggro = AliveAggressive + aggro;
+        var nBeta = AliveBeta + beta;
+        var nOblivious = AliveOblivious + oblivious;
+        Debug.Assert((uint)nAlpha <= MaxAlive);
+        Debug.Assert((uint)nAggro <= MaxAlive);
+        Debug.Assert((uint)nBeta <= MaxAlive);
+        Debug.Assert((uint)nOblivious <= MaxAlive);
+
+        var delta = (aggro + beta + oblivious);
+        var nDead = Dead - count;
+        var nGhost = nDead;
+        Debug.Assert(delta > 0);
+        Debug.Assert(count >= delta);
+        Debug.Assert((uint)nDead < Dead);
+        Debug.Assert((uint)nGhost < MaxAlive);
+        Debug.Assert(nGhost <= Dead);
+
+        return this with
+        {
+            Count = Count - count,
+            AliveAlpha = nAlpha,
+            AliveAggressive = nAggro,
+            AliveBeta = nBeta,
+            AliveOblivious = nOblivious,
+            Dead = nDead,
+            Ghost = nGhost,
+        };
+    }
+
+    public SpawnState Remove(in int aggro = 0, in int beta = 0, in int oblivious = 0)
+    {
+        // Any aggressive should prefer removing alphas for regular spawners to prevent instant despawns of future alphas.
+        var nAlpha = AliveAlpha - Math.Min(AliveAlpha, aggro);
+        var nAggro = AliveAggressive - aggro;
+        var nBeta = AliveBeta - beta;
+        var nOblivious = AliveOblivious - oblivious;
+        Debug.Assert((uint)nAlpha <= MaxAlive);
+        Debug.Assert((uint)nAggro <= MaxAlive);
+        Debug.Assert((uint)nBeta <= MaxAlive);
+        Debug.Assert((uint)nOblivious <= MaxAlive);
+
+        var delta = (aggro + beta + oblivious);
+        var nDead = Dead + delta;
+        Debug.Assert((uint)nDead <= MaxAlive);
+        Debug.Assert(delta > 0);
+
+        return this with
+        {
+            AliveAlpha = nAlpha,
+            AliveAggressive = nAggro,
+            AliveBeta = nBeta,
+            AliveOblivious = nOblivious,
+            Dead = nDead,
+        };
+    }
 
     /// <summary>
     /// Returns a spawner state with additional ghosts added.
     /// </summary>
-    public SpawnState AddGhosts(in int count) => this with
-    {
-        // These are no longer important, don't bother choosing which to decrement.
-        // We only check Ghost count going forward.
-        AliveAggressive = 0,
-        AliveOblivious = 0,
-        AliveBeta = 0,
-
-        Dead = Dead + count,
-        Ghost = Ghost + count,
-    };
+    /// <remarks> Don't care about the alive breakdown; reaching here we only care about the amount of ghosts. </remarks>
+    public SpawnState AddGhosts(in int count) => new(Count, MaxAlive, Ghost + count) { Dead = Dead + count };
 
     /// <summary>
     /// Gets the counts of what to generate when regenerating a spawner.
@@ -119,5 +135,28 @@ public readonly record struct SpawnState(in int Count, in int MaxAlive, in int G
 
         Debug.Assert(respawn != 0);
         return (emptySlots, respawn, ghosts);
+    }
+
+    public string State => GetState();
+
+    private string GetState()
+    {
+        int ctr = 0;
+        char[] result = new char[MaxAlive];
+        for (int i = 0; i < AliveAlpha; i++)
+            result[ctr++] = 'a';
+        for (int i = 0; i < AliveAggressive - AliveAlpha; i++)
+            result[ctr++] = 'A';
+        for (int i = 0; i < AliveBeta; i++)
+            result[ctr++] = 'B';
+        for (int i = 0; i < AliveOblivious; i++)
+            result[ctr++] = 'O';
+        for (int i = 0; i < Ghost; i++)
+            result[ctr++] = '~';
+        for (int i = 0; i < Dead - Ghost; i++)
+            result[ctr++] = 'X';
+        while (ctr != result.Length)
+            result[ctr++] = '?'; // shouldn't hit here besides ghosts
+        return new string(result);
     }
 }

--- a/PermuteMMO.Lib/Structure/MassOutbreakSpawner8a.cs
+++ b/PermuteMMO.Lib/Structure/MassOutbreakSpawner8a.cs
@@ -19,8 +19,8 @@ public readonly ref struct MassOutbreakSpawner8a
     public float X => BinaryPrimitives.ReadSingleLittleEndian(Data[0x20..]);
     public float Y => BinaryPrimitives.ReadSingleLittleEndian(Data[0x24..]);
     public float Z => BinaryPrimitives.ReadSingleLittleEndian(Data[0x28..]);
-    public ulong UnknownSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x30..]);
-    public ulong SpawnSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x38..]);
+    public ulong CountSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x30..]);
+    public ulong GroupSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x38..]);
     public byte BaseCount => Data[0x40];
     public uint SpawnedCount => BinaryPrimitives.ReadUInt32LittleEndian(Data[0x44..]);
     public bool HasOutbreak => AreaHash is not (0 or 0xCBF29CE484222645);

--- a/PermuteMMO.Lib/Structure/MassiveOutbreakSpawner8a.cs
+++ b/PermuteMMO.Lib/Structure/MassiveOutbreakSpawner8a.cs
@@ -23,8 +23,8 @@ public readonly ref struct MassiveOutbreakSpawner8a
     public ulong BaseTable => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x38..]);
     public ulong BonusTable => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x40..]);
     public ulong AguavSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x48..]);
-    public ulong UnknownSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x50..]);
-    public ulong SpawnSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x58..]);
+    public ulong CountSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x50..]);
+    public ulong GroupSeed => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x58..]);
     public byte BaseCount => Data[0x60];
     public uint SpawnedCount => BinaryPrimitives.ReadUInt32LittleEndian(Data[0x64..]);
     public ulong SpawnerName => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x68..]);

--- a/PermuteMMO.Lib/Util/Calculations.cs
+++ b/PermuteMMO.Lib/Util/Calculations.cs
@@ -19,8 +19,8 @@ public static class Calculations
             var rng = new Xoroshiro128Plus(seed);
             for (int i = 0; i < count; i++)
             {
-                _ = rng.Next();
-                _ = rng.Next(); // Unknown
+                _ = rng.Next(); // generate/slot seed
+                _ = rng.Next(); // alpha move
             }
             seed = rng.Next(); // Reset the seed for future spawns.
         }
@@ -36,8 +36,8 @@ public static class Calculations
         var rng = new Xoroshiro128Plus(seed);
         for (int i = 0; i < count; i++)
         {
-            _ = rng.Next();
-            _ = rng.Next(); // Unknown
+            _ = rng.Next(); // generate/slot seed
+            _ = rng.Next(); // alpha move
         }
 
         return rng.Next(); // Reset the seed for future spawns.
@@ -54,8 +54,8 @@ public static class Calculations
         var rng = new Xoroshiro128Plus(groupSeed);
         for (int i = 1; i <= spawnIndex; i++)
         {
-            var subSeed = rng.Next();
-            _ = rng.Next(); // Unknown
+            var subSeed = rng.Next(); // generate/slot seed
+            _ = rng.Next(); // alpha move, don't care
 
             if (i == spawnIndex)
                 return subSeed;
@@ -75,8 +75,8 @@ public static class Calculations
         var rng = new Xoroshiro128Plus(groupSeed);
         for (int i = 1; i <= spawnIndex; i++)
         {
-            var subSeed = rng.Next();
-            _ = rng.Next(); // Unknown
+            var subSeed = rng.Next(); // generate/slot seed
+            _ = rng.Next(); // alpha move, don't care
 
             if (i != spawnIndex)
                 continue;

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -11,6 +11,7 @@ public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next
     private static readonly SpawnDetail Outbreak = new(SpawnType.Outbreak, 4);
 
     private SpawnInfo? Next { get; set; } = Next;
+    public bool NoMultiAlpha => Detail.SpawnType is SpawnType.Regular;
 
     public string GetSummary(string prefix)
     {

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -12,6 +12,8 @@ public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next
 
     private SpawnInfo? Next { get; set; } = Next;
     public bool NoMultiAlpha => Detail.SpawnType is SpawnType.Regular;
+    public bool AllowGhosts => Detail.SpawnType is not SpawnType.Regular;
+    public bool RetainExisting => Detail.SpawnType is SpawnType.Regular;
 
     public string GetSummary(string prefix)
     {

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using PermuteMMO.Lib;
 using Xunit;
@@ -10,13 +11,27 @@ namespace PermuteMMO.Tests;
 public sealed class SimpleTests
 {
     [Theory]
-    [InlineData(0xA5D779D8831721FD, 10, 6, (ushort)25)]
-    public void First(in ulong seed, in int baseCount, in int bonusCount, in ushort species)
+    [InlineData(0xA5D779D8831721FD, 10, 6)]
+    public void First(in ulong seed, in int baseCount, in int bonusCount)
     {
         var spawner = SpawnInfo.GetMMO(0x7FA3A1DE69BD271E, baseCount, 0x44182B854CD3745D, bonusCount);
         var result = Permuter.Permute(spawner, seed);
         result.Results.Find(z => z.Entity.PID == 0x6f4edff0).Should().NotBeNull();
 
-        ConsolePermuter.PermuteSingle(spawner, seed, species);
+        var first = result.Results[0];
+        var match = RunFowardsRegenerate(seed, result, first);
+        Assert.NotNull(match);
+        match!.Entity.SlotSeed.Should().Be(first.Entity.SlotSeed);
+    }
+
+    private static PermuteResult? RunFowardsRegenerate(ulong seed, PermuteMeta result, PermuteResult first)
+    {
+        result = result.Copy(); // disassociate but keep same inputs
+        result.Criteria = (_, _) => true;
+        var (advances, entityResult) = first;
+        var steps = AdvanceRemoval.RunForwards(result, advances, seed);
+        steps.Count.Should().BeGreaterThan(0);
+
+        return result.Results.Find(z => advances.SequenceEqual(z.Advances) && entityResult.Index == z.Entity.Index);
     }
 }

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -34,4 +34,17 @@ public sealed class SimpleTests
 
         return result.Results.Find(z => advances.SequenceEqual(z.Advances) && entityResult.Index == z.Entity.Index);
     }
+
+    [Theory]
+    [InlineData(1911689355633755303u, 9, 7)]
+    public void TestForwards(in ulong seed, in int baseCount, in int bonusCount)
+    {
+        var spawner = SpawnInfo.GetMMO(0xECBF77B8F7302126, baseCount, 0x9D713CCF138FD43C, bonusCount);
+        var result = Permuter.Permute(spawner, seed).Copy();
+        var seq = new[] { Advance.A1, Advance.A1, Advance.A2, Advance.A4, Advance.CR, Advance.A2, Advance.A2 };
+
+        var _ = AdvanceRemoval.RunForwards(result, seq, seed);
+        var expect = result.Results.Where(z => seq.SequenceEqual(z.Advances));
+        expect.FirstOrDefault(z => z.Entity.IsShiny && z.Entity.Index == 2).Should().NotBeNull();
+    }
 }

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using FluentAssertions;
 using PermuteMMO.Lib;
+using PKHeX.Core;
 using Xunit;
 
 namespace PermuteMMO.Tests;
@@ -100,7 +101,7 @@ public sealed class SimpleTests
 
         const int rolls = 5;
         const int count = 2;
-        static bool IsSatisfactory(PermuteResult z) => z.Entity.Gender == 1 && z.Entity.RollCountUsed <= rolls;
+        static bool IsSatisfactory(PermuteResult z) => z.Entity.Species == (int)Species.Eevee && z.Entity.Gender == 1 && z.Entity.RollCountUsed <= rolls;
 
         var details = new SpawnDetail(SpawnType.Regular, count);
         var set = new SpawnSet(key, count);

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -49,7 +49,7 @@ public sealed class SimpleTests
     }
 
     [Theory]
-    [InlineData(1911689355633755303u)]
+    [InlineData(0xB2204D9BA549D169u)]
     public void TestMulti(in ulong seed)
     {
         var combee = new SlotDetail[]
@@ -69,13 +69,15 @@ public sealed class SimpleTests
         var spawner = SpawnInfo.GetLoop(details, set);
 
         var results = Permuter.Permute(spawner, seed, 20);
-        var min = results.Results.OrderBy(z => z.Advances.Length).FirstOrDefault();
+        var min = results.Results
+            .Where(z => z.Entity.Gender == 1 && z.Entity.RollCountUsed <= 5)
+            .OrderBy(z => z.Advances.Length).FirstOrDefault();
         min.Should().NotBeNull();
 
         var seq = min!.Advances;
         var copy = results.Copy();
         var _ = AdvanceRemoval.RunForwards(copy, seq, seed);
         var expect = copy.Results.Where(z => seq.SequenceEqual(z.Advances));
-        expect.FirstOrDefault(z => z.Entity.IsShiny && z.Entity.Index == 2).Should().NotBeNull();
+        expect.FirstOrDefault(z => z.Entity.IsShiny).Should().NotBeNull();
     }
 }

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -47,4 +47,35 @@ public sealed class SimpleTests
         var expect = result.Results.Where(z => seq.SequenceEqual(z.Advances));
         expect.FirstOrDefault(z => z.Entity.IsShiny && z.Entity.Index == 2).Should().NotBeNull();
     }
+
+    [Theory]
+    [InlineData(1911689355633755303u)]
+    public void TestMulti(in ulong seed)
+    {
+        var combee = new SlotDetail[]
+        {
+            new(100, "Combee", false, new [] {17, 20}, 0),
+            new(2, "Combee", true , new [] {32, 35}, 3),
+        };
+        foreach (var s in combee)
+            s.SetSpecies();
+
+        const ulong key = 0x1337BABECAFEDEAD;
+        SpawnGenerator.EncounterTables.Add(key, combee);
+
+        const int count = 2;
+        var details = new SpawnDetail(SpawnType.Regular, count);
+        var set = new SpawnSet(key, count);
+        var spawner = SpawnInfo.GetLoop(details, set);
+
+        var results = Permuter.Permute(spawner, seed, 20);
+        var min = results.Results.OrderBy(z => z.Advances.Length).FirstOrDefault();
+        min.Should().NotBeNull();
+
+        var seq = min!.Advances;
+        var copy = results.Copy();
+        var _ = AdvanceRemoval.RunForwards(copy, seq, seed);
+        var expect = copy.Results.Where(z => seq.SequenceEqual(z.Advances));
+        expect.FirstOrDefault(z => z.Entity.IsShiny && z.Entity.Index == 2).Should().NotBeNull();
+    }
 }

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -49,13 +49,13 @@ public static class UtilTests
         var entitySeed = Calculations.GetEntitySeed(gs, index);
         if (!spawn.GetNextWave(out var next))
             throw new Exception();
-        var result = SpawnGenerator.Generate(respawnSeed, next.Set.Table, next.Detail.SpawnType);
+        var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Detail.SpawnType);
         result.IsShiny.Should().BeTrue();
         result.IsAlpha.Should().BeTrue();
         entitySeed.Should().Be(0xc50932b428a734fd);
 
         var permute = Permuter.Permute(spawn, seed);
-        var match = permute.Results.Find(z => z.Entity.Seed == respawnSeed);
+        var match = permute.Results.Find(z => z.Entity.SlotSeed == respawnSeed);
         match.Should().NotBeNull();
     }
 
@@ -70,7 +70,7 @@ public static class UtilTests
         for (int i = 1; i <= 4; i++)
         {
             var genSeed = Calculations.GetGenerateSeed(seed, i);
-            var entity = SpawnGenerator.Generate(genSeed, spawn.Set.Table, spawn.Detail.SpawnType);
+            var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Detail.SpawnType);
             entities.Add(entity);
         }
 

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -50,6 +50,8 @@ public static class UtilTests
         if (!spawn.GetNextWave(out var next))
             throw new Exception();
         var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Detail.SpawnType, false);
+        if (result is null)
+            throw new ArgumentNullException(nameof(result));
         result.IsShiny.Should().BeTrue();
         result.IsAlpha.Should().BeTrue();
         entitySeed.Should().Be(0xc50932b428a734fd);
@@ -71,6 +73,8 @@ public static class UtilTests
         {
             var genSeed = Calculations.GetGenerateSeed(seed, i);
             var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Detail.SpawnType, false);
+            if (entity is null)
+                throw new ArgumentNullException(nameof(entity));
             entities.Add(entity);
         }
 

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -49,7 +49,7 @@ public static class UtilTests
         var entitySeed = Calculations.GetEntitySeed(gs, index);
         if (!spawn.GetNextWave(out var next))
             throw new Exception();
-        var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Detail.SpawnType);
+        var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Detail.SpawnType, false);
         result.IsShiny.Should().BeTrue();
         result.IsAlpha.Should().BeTrue();
         entitySeed.Should().Be(0xc50932b428a734fd);
@@ -70,7 +70,7 @@ public static class UtilTests
         for (int i = 1; i <= 4; i++)
         {
             var genSeed = Calculations.GetGenerateSeed(seed, i);
-            var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Detail.SpawnType);
+            var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Detail.SpawnType, false);
             entities.Add(entity);
         }
 


### PR DESCRIPTION
Currently not wired up to the Program.cs for regular use, but the `SimpleTests.cs` contains an example of permuting useful regular [X-X, same quantity] spawners like Combee and Eevee for shiny alpha females.

Added functionality:
* Can predict future state by feeding in advance sequence (no varied count spawners)
* Can permute regular spawners (not varied counts) same as MMO/MO's and get the advances required
* Tracks the count of Alpha pokemon on the field, and whether or not an Alpha can be spawned.

Not handled:
* Regular spawner slot tables -- right now, things are hardcoded and injected via the aforementioned unit tests to manually test permuting. Refer to pkNX to get ordered spawn tables & weights.
* No interaction with Console application to try permuting regular spawners.
* No advancement tracking for variable count spawners. Can potentially buffer up with rest->respawn and game the next reset to get more quantity.

Updates documentation per latest understanding of the data structures (eg count seed and alpha seed).