### PR TITLE
Multi variable spawner permutation

### DIFF
--- a/PermuteMMO.Lib/Permutation/Advance.cs
+++ b/PermuteMMO.Lib/Permutation/Advance.cs
@@ -65,14 +65,11 @@ public static class AdvanceRemoval
             if (meta.Spawner.RetainExisting)
             {
                 var count = adv.AdvanceCount();
-                state = state.KnockoutAny(count);
+                if (count != 0)
+                    state = state.KnockoutAny(count);
 
                 var newAlive = meta.Spawner.Count.GetNextCount();
-
-                var maxAlive = Math.Max(newAlive, state.Alive);
-                var newCount = Math.Max(0, maxAlive - state.Alive);
-                var newDead = maxAlive - state.Alive;
-                state = state with { MaxAlive = maxAlive, Count = newCount, Dead = newDead };
+                state = state.AdjustCount(newAlive);
                 steps.Add(new(adv, state, seed, meta.Spawner.Count.CountSeed));
             }
             else if (adv == CR)

--- a/PermuteMMO.Lib/Permutation/Advance.cs
+++ b/PermuteMMO.Lib/Permutation/Advance.cs
@@ -56,7 +56,7 @@ public static class AdvanceRemoval
     {
         List<SpawnStep> steps = new();
         var spawner = meta.Spawner;
-        var state = new SpawnState(spawner.Set.Count, spawner.Detail.MaxAlive);
+        var state = spawner.GetStartingState();
         (seed, state) = Permuter.UpdateRespawn(meta, meta.Spawner.Set.Table, seed, state);
         steps.Add(new(RG, state, seed));
         foreach (var adv in advances)
@@ -67,7 +67,7 @@ public static class AdvanceRemoval
                 var count = adv.AdvanceCount();
                 state = state.KnockoutAny(count);
 
-                var newAlive = meta.Spawner.Detail.MaxAlive; // meh
+                var newAlive = meta.Spawner.Count.GetNextCount();
 
                 var maxAlive = Math.Max(newAlive, state.MaxAlive);
                 var newCount = Math.Max(0, maxAlive - state.Alive);
@@ -79,7 +79,7 @@ public static class AdvanceRemoval
                 if (!meta.Spawner.GetNextWave(out var next))
                     throw new ArgumentException(nameof(adv));
                 meta.Spawner = next;
-                state = new SpawnState(next.Set.Count, next.Detail.MaxAlive); // reset for new wave
+                state = next.GetStartingState();
                 steps.Add(new(adv, state, seed));
             }
             else if (adv >= G1)

--- a/PermuteMMO.Lib/Permutation/Advance.cs
+++ b/PermuteMMO.Lib/Permutation/Advance.cs
@@ -69,9 +69,10 @@ public static class AdvanceRemoval
 
                 var newAlive = meta.Spawner.Count.GetNextCount();
 
-                var maxAlive = Math.Max(newAlive, state.MaxAlive);
+                var maxAlive = Math.Max(newAlive, state.Alive);
                 var newCount = Math.Max(0, maxAlive - state.Alive);
-                state = state with { MaxAlive = maxAlive, Count = newCount };
+                var newDead = maxAlive - state.Alive;
+                state = state with { MaxAlive = maxAlive, Count = newCount, Dead = newDead };
                 steps.Add(new(adv, state, seed));
             }
             else if (adv == CR)
@@ -96,7 +97,8 @@ public static class AdvanceRemoval
                 steps.Add(new(adv, state, seed));
             }
 
-            (seed, state) = Permuter.UpdateRespawn(meta, meta.Spawner.Set.Table, seed, state);
+            if (state.Count != 0)
+                (seed, state) = Permuter.UpdateRespawn(meta, meta.Spawner.Set.Table, seed, state);
             steps.Add(new(RG, state, seed));
         }
 

--- a/PermuteMMO.Lib/Permuter.cs
+++ b/PermuteMMO.Lib/Permuter.cs
@@ -52,6 +52,8 @@ public static class Permuter
 
     public static (ulong, SpawnState) UpdateRespawn(PermuteMeta meta, ulong table, ulong seed, SpawnState state)
     {
+        if (state.Count == 0)
+            return (seed, state);
         var (empty, respawn, ghosts) = state.GetRespawnInfo();
         var (reseed, alpha, aggro, beta, oblivious)
             = GenerateSpawns(meta, table, seed, empty, ghosts, state.AliveAlpha, meta.Spawner.NoMultiAlpha);
@@ -194,9 +196,7 @@ public static class Permuter
         SpawnState state;
         if (next.RetainExisting)
         {
-            var maxAlive = Math.Max(newAlive, exist.MaxAlive);
-            var newCount = Math.Max(0, maxAlive - exist.Alive);
-            state = exist with { MaxAlive = maxAlive, Count = newCount };
+            state = exist.AdjustCount(newAlive);
         }
         else
         {

--- a/PermuteMMO.Lib/Permuter.cs
+++ b/PermuteMMO.Lib/Permuter.cs
@@ -13,7 +13,7 @@ public static class Permuter
     public static PermuteMeta Permute(SpawnInfo spawner, in ulong seed, int maxDepth = 15)
     {
         var info = new PermuteMeta(spawner, maxDepth);
-        var state = new SpawnState(spawner.Set.Count, spawner.Detail.MaxAlive);
+        var state = spawner.GetStartingState();
 
         // Generate the encounters!
         PermuteRecursion(info, spawner.Set.Table, seed, state);
@@ -63,9 +63,21 @@ public static class Permuter
 
     private static void ContinuePermute(PermuteMeta meta, in ulong table, in ulong seed, in SpawnState state)
     {
+        var spawner = meta.Spawner;
         // If our spawner loops (regular), handle differently.
-        if (meta.Spawner.RetainExisting)
+        if (spawner.Type is SpawnType.Regular)
         {
+            // Try KO none if a future state can spawn more.
+            var countSeed = spawner.Count.CountSeed;
+            if (spawner.Count.CanSpawnMore(state.Alive))
+            {
+                meta.Start(Advance.RG);
+                PermuteRecursion(meta, table, seed, state);
+                meta.End();
+                spawner.Count.CountSeed = countSeed;
+            }
+
+            // Try all Knockout->Respawn steps.
             for (int i = 1; i <= state.Alive; i++)
             {
                 var step = (int)Advance.A1 + (i - 1);
@@ -73,6 +85,7 @@ public static class Permuter
                 var newState = state.KnockoutAny(i);
                 PermuteRecursion(meta, table, seed, newState);
                 meta.End();
+                spawner.Count.CountSeed = countSeed;
             }
             return;
         }
@@ -153,7 +166,7 @@ public static class Permuter
                 continue; // end of wave ghost -- ghosts spawn first!
 
             bool noAlpha = onlyOneAlpha && currentAlpha + alpha != 0;
-            var generate = SpawnGenerator.Generate(seed, i, subSeed, table, meta.Spawner.Detail.SpawnType, noAlpha);
+            var generate = SpawnGenerator.Generate(seed, i, subSeed, table, meta.Spawner.Type, noAlpha);
             if (generate is null) // only a consideration for spawners with 100% static alphas, qty >1, maybe some weather/time tables?
                 continue; // empty ghost slot -- spawn failure.
 
@@ -176,7 +189,7 @@ public static class Permuter
 
         var current = meta.Spawner;
         meta.Spawner = next;
-        var newAlive = next.Detail.MaxAlive;
+        var newAlive = next.Count.GetNextCount();
 
         SpawnState state;
         if (next.RetainExisting)
@@ -187,8 +200,7 @@ public static class Permuter
         }
         else
         {
-            var newCount = next.Set.Count;
-            state = new SpawnState(newCount, newAlive);
+            state = next.GetStartingState();
         }
         PermuteOutbreak(meta, next.Set.Table, seed, state);
 

--- a/PermuteMMO.Lib/SpawnState.cs
+++ b/PermuteMMO.Lib/SpawnState.cs
@@ -31,6 +31,9 @@ public readonly record struct SpawnState(in int Count, in int MaxAlive, in int G
     /// <remarks> Only call this if <see cref="Count"/> is zero. </remarks>
     public int EmptyGhostSlots => MaxGhosts - Ghost;
 
+    public static SpawnState Get(int count) => Get(count, count);
+    public static SpawnState Get(int totalCount, int aliveCount) => new(totalCount, aliveCount);
+
     /// <summary>
     /// Returns a spawner state after knocking out existing entities.
     /// </summary>

--- a/PermuteMMO.Lib/SpawnState.cs
+++ b/PermuteMMO.Lib/SpawnState.cs
@@ -130,6 +130,14 @@ public readonly record struct SpawnState(in int Count, in int MaxAlive, in int G
         };
     }
 
+    public SpawnState AdjustCount(int newAlive)
+    {
+        var maxAlive = Math.Max(newAlive, Alive);
+        var newCount = Math.Max(0, maxAlive - Alive);
+        var newDead = maxAlive - Alive;
+        return this with { MaxAlive = maxAlive, Count = newCount, Dead = newDead };
+    }
+
     /// <summary>
     /// Returns a spawner state with additional ghosts added.
     /// </summary>

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -1,19 +1,20 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using PKHeX.Core;
 
 namespace PermuteMMO.Lib;
 
 /// <summary>
 /// Top-level spawner details to feed into the permutation logic.
 /// </summary>
-public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next = null)
+public sealed record SpawnInfo(SpawnCount Count, SpawnSet Set, SpawnType Type, SpawnInfo? Next = null)
 {
-    private static readonly SpawnDetail MMO = new(SpawnType.MMO, 4);
-    private static readonly SpawnDetail Outbreak = new(SpawnType.Outbreak, 4);
+    private static readonly SpawnCount MMO = new(4, 4);
+    private static readonly SpawnCount Outbreak = new(4, 4);
 
     private SpawnInfo? Next { get; set; } = Next;
-    public bool NoMultiAlpha => Detail.SpawnType is SpawnType.Regular;
-    public bool AllowGhosts => Detail.SpawnType is not SpawnType.Regular;
-    public bool RetainExisting => Detail.SpawnType is SpawnType.Regular;
+    public bool NoMultiAlpha => Type is SpawnType.Regular;
+    public bool AllowGhosts => Type is not SpawnType.Regular;
+    public bool RetainExisting => Type is SpawnType.Regular;
 
     public string GetSummary(string prefix)
     {
@@ -27,27 +28,34 @@ public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next
 
     public bool GetNextWave([NotNullWhen(true)] out SpawnInfo? next) => (next = Next) != null;
 
-    public SpawnInfo(MassiveOutbreakSpawner8a spawner) : this(MMO, new SpawnSet(spawner.BaseTable, spawner.BaseCount), GetBonusChain(spawner)) { }
-    public SpawnInfo(MassOutbreakSpawner8a spawner) : this(Outbreak, new SpawnSet(spawner.DisplaySpecies, spawner.BaseCount)) { }
+    public SpawnInfo(MassiveOutbreakSpawner8a spawner) : this(MMO, new SpawnSet(spawner.BaseTable, spawner.BaseCount), SpawnType.MMO, GetBonusChain(spawner)) { }
+    public SpawnInfo(MassOutbreakSpawner8a spawner) : this(Outbreak, new SpawnSet(spawner.DisplaySpecies, spawner.BaseCount), SpawnType.Outbreak) { }
 
     public static SpawnInfo GetMMO(ulong baseTable, in int baseCount, ulong bonusTable, in int bonusCount)
     {
-        var child = new SpawnInfo(MMO, new SpawnSet(bonusTable, bonusCount));
-        return new SpawnInfo(MMO, new SpawnSet(baseTable, baseCount), child);
+        var child = new SpawnInfo(MMO, new SpawnSet(bonusTable, bonusCount), SpawnType.MMO);
+        return new SpawnInfo(MMO, new SpawnSet(baseTable, baseCount), SpawnType.MMO, child);
+    }
+
+    public SpawnState GetStartingState()
+    {
+        if (Type is SpawnType.Regular)
+            return SpawnState.Get(Count.GetNextCount());
+        return SpawnState.Get(Set.Count, Count.MaxAlive);
     }
 
     private static SpawnInfo? GetBonusChain(MassiveOutbreakSpawner8a spawner)
     {
         if (!spawner.HasBonus)
             return null;
-        return new SpawnInfo(MMO, new SpawnSet(spawner.BonusTable, spawner.BonusCount));
+        return new SpawnInfo(MMO, new SpawnSet(spawner.BonusTable, spawner.BonusCount), SpawnType.MMO);
     }
 
-    public static SpawnInfo GetMO(ulong table, int count) => new(Outbreak, new SpawnSet(table, count));
+    public static SpawnInfo GetMO(ulong table, int count) => new(Outbreak, new SpawnSet(table, count), SpawnType.Outbreak);
 
-    public static SpawnInfo GetLoop(SpawnDetail detail, SpawnSet set)
+    public static SpawnInfo GetLoop(SpawnCount count, SpawnSet set, SpawnType type)
     {
-        var result = new SpawnInfo(detail, set);
+        var result = new SpawnInfo(count, set, type);
         result.Next = result;
         return result;
     }
@@ -55,7 +63,41 @@ public sealed record SpawnInfo(SpawnDetail Detail, SpawnSet Set, SpawnInfo? Next
 
 public readonly record struct SpawnSet(ulong Table, int Count);
 
-public readonly record struct SpawnDetail(SpawnType SpawnType, int MaxAlive);
+public record SpawnCount(int MaxAlive, int MinAlive = 0, ulong CountSeed = 0)
+{
+    public ulong CountSeed { get; set; } = CountSeed;
+
+    public bool IsFixedCount => MinAlive is 0 || MinAlive == MaxAlive;
+
+    public int GetNextCount()
+    {
+        if (IsFixedCount)
+            return MaxAlive;
+        var rand = new Xoroshiro128Plus(CountSeed);
+        var delta = MinAlive - MaxAlive;
+        var result = (int)rand.NextInt((uint)delta + 1);
+        CountSeed = rand.Next();
+        return result;
+    }
+
+    private int PeekNextCount()
+    {
+        var rand = new Xoroshiro128Plus(CountSeed);
+        var delta = MinAlive - MaxAlive;
+        return (int)rand.NextInt((uint)delta + 1);
+    }
+
+    public bool CanSpawnMore(int currentMaxAlive)
+    {
+        if (IsFixedCount)
+            return false;
+
+        var nextMaxAlive = PeekNextCount();
+        if (nextMaxAlive > currentMaxAlive)
+            return true;
+        return nextMaxAlive == currentMaxAlive && nextMaxAlive != MaxAlive;
+    }
+}
 
 public static class HashUtil
 {

--- a/PermuteMMO.Lib/Util/SpawnInfo.cs
+++ b/PermuteMMO.Lib/Util/SpawnInfo.cs
@@ -74,8 +74,8 @@ public record SpawnCount(int MaxAlive, int MinAlive = 0, ulong CountSeed = 0)
         if (IsFixedCount)
             return MaxAlive;
         var rand = new Xoroshiro128Plus(CountSeed);
-        var delta = MinAlive - MaxAlive;
-        var result = (int)rand.NextInt((uint)delta + 1);
+        var delta = MaxAlive - MinAlive;
+        var result = MinAlive + (int)rand.NextInt((uint)delta + 1);
         CountSeed = rand.Next();
         return result;
     }
@@ -83,8 +83,8 @@ public record SpawnCount(int MaxAlive, int MinAlive = 0, ulong CountSeed = 0)
     private int PeekNextCount()
     {
         var rand = new Xoroshiro128Plus(CountSeed);
-        var delta = MinAlive - MaxAlive;
-        return (int)rand.NextInt((uint)delta + 1);
+        var delta = MaxAlive - MinAlive;
+        return MinAlive + (int)rand.NextInt((uint)delta + 1);
     }
 
     public bool CanSpawnMore(int currentMaxAlive)

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -65,9 +65,9 @@ public sealed class SimpleTests
         SpawnGenerator.EncounterTables.Add(key, combee);
 
         const int count = 2;
-        var details = new SpawnDetail(SpawnType.Regular, count);
+        var details = new SpawnCount(count, count);
         var set = new SpawnSet(key, count);
-        var spawner = SpawnInfo.GetLoop(details, set);
+        var spawner = SpawnInfo.GetLoop(details, set, SpawnType.Regular);
 
         var results = Permuter.Permute(spawner, seed, 20);
         var min = results.Results
@@ -103,9 +103,9 @@ public sealed class SimpleTests
         const int count = 2;
         static bool IsSatisfactory(PermuteResult z) => z.Entity.Species == (int)Species.Eevee && z.Entity.Gender == 1 && z.Entity.RollCountUsed <= rolls;
 
-        var details = new SpawnDetail(SpawnType.Regular, count);
+        var details = new SpawnCount(count, count);
         var set = new SpawnSet(key, count);
-        var spawner = SpawnInfo.GetLoop(details, set);
+        var spawner = SpawnInfo.GetLoop(details, set, SpawnType.Regular);
 
         var results = Permuter.Permute(spawner, seed, 20);
         var min = results.Results

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -101,7 +101,7 @@ public sealed class SimpleTests
         var set = new SpawnSet(key, 0);
         var spawner = SpawnInfo.GetLoop(details, set, SpawnType.Regular);
 
-        var results = Permuter.Permute(spawner, seed, 10);
+        var results = Permuter.Permute(spawner, seed, 12);
         var min = results.Results
             .MinBy(z => z.Advances.Length);
         min.Should().NotBeNull();

--- a/PermuteMMO.Tests/SimpleTests.cs
+++ b/PermuteMMO.Tests/SimpleTests.cs
@@ -90,8 +90,9 @@ public sealed class SimpleTests
         const ulong key = 9489890319879407414;
         for (int i = 0; i < slots.Length/2; i++)
         {
-            slots[i]      = new(100, "Unown", false, new[] { 25, 25 }, 0);
-            slots[i + 28] = new(001, "Unown", true , new[] { 25, 25 }, 3);
+            var name = $"Unown{(i == 0 ? "" : $"-{i}")}";
+            slots[i]      = new(100, name, false, new[] { 25, 25 }, 0);
+            slots[i + 28] = new(001, name, true , new[] { 25, 25 }, 3);
         }
         SetFakeTable(slots, key);
 

--- a/PermuteMMO.Tests/UtilTests.cs
+++ b/PermuteMMO.Tests/UtilTests.cs
@@ -49,7 +49,7 @@ public static class UtilTests
         var entitySeed = Calculations.GetEntitySeed(gs, index);
         if (!spawn.GetNextWave(out var next))
             throw new Exception();
-        var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Detail.SpawnType, false);
+        var result = SpawnGenerator.Generate(seed, index, respawnSeed, next.Set.Table, next.Type, false);
         if (result is null)
             throw new ArgumentNullException(nameof(result));
         result.IsShiny.Should().BeTrue();
@@ -72,7 +72,7 @@ public static class UtilTests
         for (int i = 1; i <= 4; i++)
         {
             var genSeed = Calculations.GetGenerateSeed(seed, i);
-            var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Detail.SpawnType, false);
+            var entity = SpawnGenerator.Generate(seed, i, genSeed, spawn.Set.Table, spawn.Type, false);
             if (entity is null)
                 throw new ArgumentNullException(nameof(entity));
             entities.Add(entity);


### PR DESCRIPTION
Adds logic to handle variable count spawners such as the Unown in Solaceon Ruins.