### PR TITLE
Updated mini search paths functionality

### DIFF
--- a/PermuteMMO.Lib/Generation/EntityResult.cs
+++ b/PermuteMMO.Lib/Generation/EntityResult.cs
@@ -30,6 +30,7 @@ public sealed record EntityResult(SlotDetail Slot)
 
     public bool IsShiny { get; set; }
     public bool IsAlpha { get; init; }
+    public bool IsMini { get; set; }
     public byte Ability { get; set; }
     public byte Gender { get; set; }
     public byte Nature { get; set; }
@@ -47,13 +48,14 @@ public sealed record EntityResult(SlotDetail Slot)
         var nature = $" {GameInfo.GetStrings(1).Natures[Nature]}";
         var alpha = IsAlpha ? "α-" : "  ";
         var notAlpha = !IsAlpha ? " -- NOT ALPHA" : "";
+        var mini = !IsMini ? "" : " Mini";
         var gender = Gender switch
         {
             2 => "",
             1 => " (F)",
             _ => " (M)",
         };
-        return $"{alpha}{Slot.Name}{gender}:{shiny}{ivs}{nature,-8}{notAlpha}";
+        return $"{alpha}{Slot.Name}{gender}:{shiny}{ivs}{nature,-8}{notAlpha}{mini}";
     }
 
     public IEnumerable<string> GetLines()

--- a/PermuteMMO.Lib/Generation/SpawnGenerator.cs
+++ b/PermuteMMO.Lib/Generation/SpawnGenerator.cs
@@ -186,6 +186,8 @@ public static class SpawnGenerator
             ? (byte.MaxValue, byte.MaxValue)
             : ((byte)((int)rng.NextInt(0x81) + (int)rng.NextInt(0x80)),
                (byte)((int)rng.NextInt(0x81) + (int)rng.NextInt(0x80)));
+
+        result.IsMini = !result.IsAlpha && result.Height == 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
I changed the code so that now users can also search for mini (XXXS) pokemon (Height == 0), and mini shinies.

In parallel, I also created a pull request for ForkBot.NET so that users of that bot are able to search those minis as well.